### PR TITLE
Исправлена ошибка имени файла после ресайза

### DIFF
--- a/oi.file.js
+++ b/oi.file.js
@@ -334,7 +334,7 @@ angular.module('oi.file', [])
           xhr.item = uObj.item;
           uObj.xhr = xhr;
           
-          form.append(opts.fieldName, uObj.item._file);
+          form.append(opts.fieldName, uObj.item._file, uObj.item.filename);
           
           xhr.upload.addEventListener('progress', function (e) {
             


### PR DESCRIPTION
Заменив объект File после ресайза на Blob имя файла при загрузке станет "blob". 3ий аргумент форсит имя файла в форме. + можно задать теперь имя файла самому.
